### PR TITLE
feat: implement APU (Audio Processing Unit)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,8 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v4
+    - name: Install system dependencies
+      run: apt-get update && apt-get install -y libasound2-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,8 +90,8 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown",
  "static_assertions",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -128,6 +128,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,9 +172,9 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -386,6 +417,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +595,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -629,6 +698,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +766,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dispatch"
@@ -695,6 +813,7 @@ dependencies = [
 name = "dmg-emu"
 version = "0.1.0"
 dependencies = [
+ "cpal",
  "eframe",
  "egui",
 ]
@@ -841,6 +960,12 @@ dependencies = [
  "web-sys",
  "winit",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -1102,6 +1227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1652,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1540,6 +1695,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.9.1",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -1547,7 +1716,7 @@ dependencies = [
  "bitflags 2.9.1",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1558,6 +1727,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -1586,6 +1764,27 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-traits"
@@ -1891,6 +2090,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2353,35 @@ checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2990,12 +3241,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -3007,7 +3268,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3019,7 +3290,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings",
 ]
 
@@ -3029,7 +3300,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
  "windows-threading",
 ]
@@ -3068,8 +3339,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3400,7 +3680,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ name = "emulator"
 opt-level = 0
 
 [dependencies]
+cpal = "0.15"
 eframe = "0.32.0"
 egui = "0.32.0"

--- a/src/emulator/apu.rs
+++ b/src/emulator/apu.rs
@@ -1,0 +1,928 @@
+const DUTY_TABLE: [[u8; 8]; 4] = [
+    [0, 0, 0, 0, 0, 0, 0, 1], // 12.5%
+    [1, 0, 0, 0, 0, 0, 0, 1], // 25%
+    [1, 0, 0, 0, 0, 1, 1, 1], // 50%
+    [0, 1, 1, 1, 1, 1, 1, 0], // 75%
+];
+
+// Read masks: bits that return 1 on read (write-only bits)
+const NR10_READ_MASK: u8 = 0x80;
+const NR11_READ_MASK: u8 = 0x3F; // only duty bits readable
+const NR12_READ_MASK: u8 = 0x00;
+const NR13_READ_MASK: u8 = 0xFF; // write-only
+const NR14_READ_MASK: u8 = 0xBF; // bit 6 readable, rest masked
+const NR21_READ_MASK: u8 = 0x3F;
+const NR22_READ_MASK: u8 = 0x00;
+const NR23_READ_MASK: u8 = 0xFF;
+const NR24_READ_MASK: u8 = 0xBF;
+const NR30_READ_MASK: u8 = 0x7F;
+const NR31_READ_MASK: u8 = 0xFF;
+const NR32_READ_MASK: u8 = 0x9F;
+const NR33_READ_MASK: u8 = 0xFF;
+const NR34_READ_MASK: u8 = 0xBF;
+const NR41_READ_MASK: u8 = 0xFF;
+const NR42_READ_MASK: u8 = 0x00;
+const NR43_READ_MASK: u8 = 0x00;
+const NR44_READ_MASK: u8 = 0xBF;
+
+const CPU_CLOCK: u32 = 4_194_304;
+const FRAME_SEQUENCER_RATE: u16 = 8192; // CPU clocks per frame sequencer tick
+
+#[derive(Debug, Clone)]
+pub struct SquareChannel {
+    pub enabled: bool,
+
+    // Sweep (channel 1 only)
+    pub has_sweep: bool,
+    sweep_pace: u8,
+    sweep_direction: bool, // false = add, true = subtract
+    sweep_step: u8,
+    sweep_timer: u8,
+    sweep_shadow_freq: u16,
+    sweep_enabled: bool,
+
+    // Duty
+    duty: u8,
+    duty_position: u8,
+
+    // Length
+    length_counter: u16,
+    length_enabled: bool,
+
+    // Volume envelope
+    initial_volume: u8,
+    envelope_direction: bool, // false = down, true = up
+    envelope_pace: u8,
+    envelope_timer: u8,
+    current_volume: u8,
+
+    // Frequency
+    frequency: u16,
+    frequency_timer: u16,
+
+    // Raw registers
+    pub nr0: u8, // NR10 (ch1) or unused (ch2)
+    pub nr1: u8, // NRx1
+    pub nr2: u8, // NRx2
+    pub nr3: u8, // NRx3
+    pub nr4: u8, // NRx4
+}
+
+impl SquareChannel {
+    pub fn new(has_sweep: bool) -> Self {
+        Self {
+            enabled: false,
+            has_sweep,
+            sweep_pace: 0,
+            sweep_direction: false,
+            sweep_step: 0,
+            sweep_timer: 0,
+            sweep_shadow_freq: 0,
+            sweep_enabled: false,
+            duty: 0,
+            duty_position: 0,
+            length_counter: 0,
+            length_enabled: false,
+            initial_volume: 0,
+            envelope_direction: false,
+            envelope_pace: 0,
+            envelope_timer: 0,
+            current_volume: 0,
+            frequency: 0,
+            frequency_timer: 0,
+            nr0: 0,
+            nr1: 0,
+            nr2: 0,
+            nr3: 0,
+            nr4: 0,
+        }
+    }
+
+    pub fn write_register(&mut self, reg: u8, value: u8) {
+        match reg {
+            0 => {
+                // NRx0 (sweep, channel 1 only)
+                self.nr0 = value;
+                if self.has_sweep {
+                    self.sweep_pace = (value >> 4) & 0x07;
+                    self.sweep_direction = (value & 0x08) != 0;
+                    self.sweep_step = value & 0x07;
+                }
+            }
+            1 => {
+                // NRx1 (duty + length)
+                self.nr1 = value;
+                self.duty = (value >> 6) & 0x03;
+                self.length_counter = 64 - (value & 0x3F) as u16;
+            }
+            2 => {
+                // NRx2 (volume envelope)
+                self.nr2 = value;
+                self.initial_volume = (value >> 4) & 0x0F;
+                self.envelope_direction = (value & 0x08) != 0;
+                self.envelope_pace = value & 0x07;
+
+                // DAC disabled if top 5 bits are 0
+                if value & 0xF8 == 0 {
+                    self.enabled = false;
+                }
+            }
+            3 => {
+                // NRx3 (frequency low)
+                self.nr3 = value;
+                self.frequency = (self.frequency & 0x700) | value as u16;
+            }
+            4 => {
+                // NRx4 (trigger + length enable + frequency high)
+                self.nr4 = value;
+                self.frequency = (self.frequency & 0xFF) | (((value & 0x07) as u16) << 8);
+                self.length_enabled = (value & 0x40) != 0;
+
+                if value & 0x80 != 0 {
+                    self.trigger();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn trigger(&mut self) {
+        self.enabled = true;
+
+        if self.length_counter == 0 {
+            self.length_counter = 64;
+        }
+
+        self.frequency_timer = (2048 - self.frequency) * 4;
+        self.current_volume = self.initial_volume;
+        self.envelope_timer = self.envelope_pace;
+
+        // DAC check
+        if self.nr2 & 0xF8 == 0 {
+            self.enabled = false;
+        }
+
+        // Sweep init (channel 1)
+        if self.has_sweep {
+            self.sweep_shadow_freq = self.frequency;
+            self.sweep_timer = if self.sweep_pace != 0 {
+                self.sweep_pace
+            } else {
+                8
+            };
+            self.sweep_enabled = self.sweep_pace != 0 || self.sweep_step != 0;
+
+            if self.sweep_step != 0 {
+                let new_freq = self.calculate_sweep_frequency();
+                if new_freq > 2047 {
+                    self.enabled = false;
+                }
+            }
+        }
+    }
+
+    fn calculate_sweep_frequency(&self) -> u16 {
+        let shifted = self.sweep_shadow_freq >> self.sweep_step;
+        if self.sweep_direction {
+            self.sweep_shadow_freq.wrapping_sub(shifted)
+        } else {
+            self.sweep_shadow_freq.wrapping_add(shifted)
+        }
+    }
+
+    pub fn step_frequency(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+        if self.frequency_timer == 0 {
+            self.frequency_timer = (2048 - self.frequency) * 4;
+            self.duty_position = (self.duty_position + 1) % 8;
+        }
+    }
+
+    pub fn step_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    pub fn step_envelope(&mut self) {
+        if self.envelope_pace == 0 {
+            return;
+        }
+
+        if self.envelope_timer > 0 {
+            self.envelope_timer -= 1;
+        }
+
+        if self.envelope_timer == 0 {
+            self.envelope_timer = self.envelope_pace;
+
+            if self.envelope_direction && self.current_volume < 15 {
+                self.current_volume += 1;
+            } else if !self.envelope_direction && self.current_volume > 0 {
+                self.current_volume -= 1;
+            }
+        }
+    }
+
+    pub fn step_sweep(&mut self) {
+        if !self.has_sweep {
+            return;
+        }
+
+        if self.sweep_timer > 0 {
+            self.sweep_timer -= 1;
+        }
+
+        if self.sweep_timer == 0 {
+            self.sweep_timer = if self.sweep_pace != 0 {
+                self.sweep_pace
+            } else {
+                8
+            };
+
+            if self.sweep_enabled && self.sweep_pace != 0 {
+                let new_freq = self.calculate_sweep_frequency();
+                if new_freq > 2047 {
+                    self.enabled = false;
+                } else if self.sweep_step != 0 {
+                    self.sweep_shadow_freq = new_freq;
+                    self.frequency = new_freq;
+
+                    // Overflow check again
+                    if self.calculate_sweep_frequency() > 2047 {
+                        self.enabled = false;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn output(&self) -> f32 {
+        if !self.enabled {
+            return 0.0;
+        }
+        let sample = DUTY_TABLE[self.duty as usize][self.duty_position as usize];
+        (sample as f32) * (self.current_volume as f32 / 15.0)
+    }
+
+    pub fn reset(&mut self) {
+        let has_sweep = self.has_sweep;
+        *self = Self::new(has_sweep);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WaveChannel {
+    pub enabled: bool,
+
+    // Length
+    length_counter: u16,
+    length_enabled: bool,
+
+    // Volume
+    volume_code: u8,
+
+    // Frequency
+    frequency: u16,
+    frequency_timer: u16,
+
+    // Wave RAM
+    pub wave_ram: [u8; 16],
+    wave_position: u8,
+
+    // DAC
+    dac_enabled: bool,
+
+    // Raw registers
+    pub nr0: u8, // NR30
+    pub nr1: u8, // NR31
+    pub nr2: u8, // NR32
+    pub nr3: u8, // NR33
+    pub nr4: u8, // NR34
+}
+
+impl Default for WaveChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WaveChannel {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            length_counter: 0,
+            length_enabled: false,
+            volume_code: 0,
+            frequency: 0,
+            frequency_timer: 0,
+            wave_ram: [0; 16],
+            wave_position: 0,
+            dac_enabled: false,
+            nr0: 0,
+            nr1: 0,
+            nr2: 0,
+            nr3: 0,
+            nr4: 0,
+        }
+    }
+
+    pub fn write_register(&mut self, reg: u8, value: u8) {
+        match reg {
+            0 => {
+                // NR30 - DAC enable
+                self.nr0 = value;
+                self.dac_enabled = (value & 0x80) != 0;
+                if !self.dac_enabled {
+                    self.enabled = false;
+                }
+            }
+            1 => {
+                // NR31 - Length
+                self.nr1 = value;
+                self.length_counter = 256 - value as u16;
+            }
+            2 => {
+                // NR32 - Volume code
+                self.nr2 = value;
+                self.volume_code = (value >> 5) & 0x03;
+            }
+            3 => {
+                // NR33 - Frequency low
+                self.nr3 = value;
+                self.frequency = (self.frequency & 0x700) | value as u16;
+            }
+            4 => {
+                // NR34 - Trigger + length enable + frequency high
+                self.nr4 = value;
+                self.frequency = (self.frequency & 0xFF) | (((value & 0x07) as u16) << 8);
+                self.length_enabled = (value & 0x40) != 0;
+
+                if value & 0x80 != 0 {
+                    self.trigger();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn trigger(&mut self) {
+        self.enabled = true;
+
+        if self.length_counter == 0 {
+            self.length_counter = 256;
+        }
+
+        self.frequency_timer = (2048 - self.frequency) * 2;
+        self.wave_position = 0;
+
+        if !self.dac_enabled {
+            self.enabled = false;
+        }
+    }
+
+    pub fn step_frequency(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+        if self.frequency_timer == 0 {
+            self.frequency_timer = (2048 - self.frequency) * 2;
+            self.wave_position = (self.wave_position + 1) % 32;
+        }
+    }
+
+    pub fn step_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    pub fn output(&self) -> f32 {
+        if !self.enabled || !self.dac_enabled {
+            return 0.0;
+        }
+
+        let byte_index = (self.wave_position / 2) as usize;
+        let sample = if self.wave_position.is_multiple_of(2) {
+            (self.wave_ram[byte_index] >> 4) & 0x0F
+        } else {
+            self.wave_ram[byte_index] & 0x0F
+        };
+
+        let shifted = match self.volume_code {
+            0 => sample >> 4, // mute (shift by 4 = 0)
+            1 => sample,      // 100%
+            2 => sample >> 1, // 50%
+            3 => sample >> 2, // 25%
+            _ => 0,
+        };
+
+        shifted as f32 / 15.0
+    }
+
+    pub fn reset(&mut self) {
+        let wave_ram = self.wave_ram;
+        *self = Self::new();
+        self.wave_ram = wave_ram; // Wave RAM persists across APU power off
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoiseChannel {
+    pub enabled: bool,
+
+    // Length
+    length_counter: u16,
+    length_enabled: bool,
+
+    // Volume envelope
+    initial_volume: u8,
+    envelope_direction: bool,
+    envelope_pace: u8,
+    envelope_timer: u8,
+    current_volume: u8,
+
+    // Noise
+    clock_shift: u8,
+    width_mode: bool, // false = 15-bit, true = 7-bit
+    divisor_code: u8,
+    lfsr: u16,
+    frequency_timer: u32,
+
+    // Raw registers
+    pub nr1: u8, // NR41
+    pub nr2: u8, // NR42
+    pub nr3: u8, // NR43
+    pub nr4: u8, // NR44
+}
+
+impl Default for NoiseChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NoiseChannel {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            length_counter: 0,
+            length_enabled: false,
+            initial_volume: 0,
+            envelope_direction: false,
+            envelope_pace: 0,
+            envelope_timer: 0,
+            current_volume: 0,
+            clock_shift: 0,
+            width_mode: false,
+            divisor_code: 0,
+            lfsr: 0x7FFF,
+            frequency_timer: 0,
+            nr1: 0,
+            nr2: 0,
+            nr3: 0,
+            nr4: 0,
+        }
+    }
+
+    pub fn write_register(&mut self, reg: u8, value: u8) {
+        match reg {
+            1 => {
+                // NR41 - Length
+                self.nr1 = value;
+                self.length_counter = 64 - (value & 0x3F) as u16;
+            }
+            2 => {
+                // NR42 - Volume envelope
+                self.nr2 = value;
+                self.initial_volume = (value >> 4) & 0x0F;
+                self.envelope_direction = (value & 0x08) != 0;
+                self.envelope_pace = value & 0x07;
+
+                if value & 0xF8 == 0 {
+                    self.enabled = false;
+                }
+            }
+            3 => {
+                // NR43 - Polynomial counter
+                self.nr3 = value;
+                self.clock_shift = (value >> 4) & 0x0F;
+                self.width_mode = (value & 0x08) != 0;
+                self.divisor_code = value & 0x07;
+            }
+            4 => {
+                // NR44 - Trigger + length enable
+                self.nr4 = value;
+                self.length_enabled = (value & 0x40) != 0;
+
+                if value & 0x80 != 0 {
+                    self.trigger();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn trigger(&mut self) {
+        self.enabled = true;
+
+        if self.length_counter == 0 {
+            self.length_counter = 64;
+        }
+
+        self.frequency_timer = self.get_frequency_timer();
+        self.lfsr = 0x7FFF;
+        self.current_volume = self.initial_volume;
+        self.envelope_timer = self.envelope_pace;
+
+        if self.nr2 & 0xF8 == 0 {
+            self.enabled = false;
+        }
+    }
+
+    fn get_frequency_timer(&self) -> u32 {
+        let divisor: u32 = match self.divisor_code {
+            0 => 8,
+            n => (n as u32) * 16,
+        };
+        divisor << self.clock_shift
+    }
+
+    pub fn step_frequency(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+        if self.frequency_timer == 0 {
+            self.frequency_timer = self.get_frequency_timer();
+
+            let xor_result = (self.lfsr & 0x01) ^ ((self.lfsr >> 1) & 0x01);
+            self.lfsr = (self.lfsr >> 1) | (xor_result << 14);
+
+            if self.width_mode {
+                self.lfsr &= !(1 << 6);
+                self.lfsr |= xor_result << 6;
+            }
+        }
+    }
+
+    pub fn step_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    pub fn step_envelope(&mut self) {
+        if self.envelope_pace == 0 {
+            return;
+        }
+
+        if self.envelope_timer > 0 {
+            self.envelope_timer -= 1;
+        }
+
+        if self.envelope_timer == 0 {
+            self.envelope_timer = self.envelope_pace;
+
+            if self.envelope_direction && self.current_volume < 15 {
+                self.current_volume += 1;
+            } else if !self.envelope_direction && self.current_volume > 0 {
+                self.current_volume -= 1;
+            }
+        }
+    }
+
+    pub fn output(&self) -> f32 {
+        if !self.enabled {
+            return 0.0;
+        }
+        // LFSR bit 0 inverted
+        let sample = if self.lfsr & 0x01 == 0 { 1.0 } else { 0.0 };
+        sample * (self.current_volume as f32 / 15.0)
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct APU {
+    // Control registers
+    pub nr50: u8, // 0xFF24 - Volume / VIN
+    pub nr51: u8, // 0xFF25 - Panning
+    pub nr52: u8, // 0xFF26 - Power control
+
+    // 4 channels
+    pub channel1: SquareChannel,
+    pub channel2: SquareChannel,
+    pub channel3: WaveChannel,
+    pub channel4: NoiseChannel,
+
+    // Frame sequencer (512 Hz = CPU_CLOCK / 8192)
+    frame_sequencer_counter: u16,
+    frame_sequencer_step: u8, // 0..7
+
+    // Sample generation
+    sample_counter: u32,
+    sample_rate: u32,
+    sample_buffer: Vec<(f32, f32)>,
+}
+
+impl Default for APU {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl APU {
+    pub fn new() -> Self {
+        Self {
+            nr50: 0,
+            nr51: 0,
+            nr52: 0,
+            channel1: SquareChannel::new(true),
+            channel2: SquareChannel::new(false),
+            channel3: WaveChannel::new(),
+            channel4: NoiseChannel::new(),
+            frame_sequencer_counter: 0,
+            frame_sequencer_step: 0,
+            sample_counter: 0,
+            sample_rate: 44100,
+            sample_buffer: Vec::new(),
+        }
+    }
+
+    fn is_powered(&self) -> bool {
+        self.nr52 & 0x80 != 0
+    }
+
+    pub fn read_register(&self, address: u16) -> u8 {
+        match address {
+            // Channel 1 registers
+            0xFF10 => self.channel1.nr0 | NR10_READ_MASK,
+            0xFF11 => self.channel1.nr1 | NR11_READ_MASK,
+            0xFF12 => self.channel1.nr2 | NR12_READ_MASK,
+            0xFF13 => NR13_READ_MASK, // write-only
+            0xFF14 => self.channel1.nr4 | NR14_READ_MASK,
+
+            // Channel 2 registers
+            0xFF15 => 0xFF, // NR20 doesn't exist
+            0xFF16 => self.channel2.nr1 | NR21_READ_MASK,
+            0xFF17 => self.channel2.nr2 | NR22_READ_MASK,
+            0xFF18 => NR23_READ_MASK, // write-only
+            0xFF19 => self.channel2.nr4 | NR24_READ_MASK,
+
+            // Channel 3 registers
+            0xFF1A => self.channel3.nr0 | NR30_READ_MASK,
+            0xFF1B => NR31_READ_MASK, // write-only
+            0xFF1C => self.channel3.nr2 | NR32_READ_MASK,
+            0xFF1D => NR33_READ_MASK, // write-only
+            0xFF1E => self.channel3.nr4 | NR34_READ_MASK,
+
+            // Channel 4 registers
+            0xFF1F => 0xFF, // unused
+            0xFF20 => NR41_READ_MASK, // write-only
+            0xFF21 => self.channel4.nr2 | NR42_READ_MASK,
+            0xFF22 => self.channel4.nr3 | NR43_READ_MASK,
+            0xFF23 => self.channel4.nr4 | NR44_READ_MASK,
+
+            // Control registers
+            0xFF24 => self.nr50,
+            0xFF25 => self.nr51,
+            0xFF26 => {
+                let mut value = self.nr52 & 0x80;
+                value |= 0x70; // bits 4-6 always read as 1
+                if self.channel1.enabled {
+                    value |= 0x01;
+                }
+                if self.channel2.enabled {
+                    value |= 0x02;
+                }
+                if self.channel3.enabled {
+                    value |= 0x04;
+                }
+                if self.channel4.enabled {
+                    value |= 0x08;
+                }
+                value
+            }
+
+            // Wave RAM
+            0xFF30..=0xFF3F => {
+                let index = (address - 0xFF30) as usize;
+                self.channel3.wave_ram[index]
+            }
+
+            _ => 0xFF,
+        }
+    }
+
+    pub fn write_register(&mut self, address: u16, value: u8) {
+        // Wave RAM is always writable
+        if (0xFF30..=0xFF3F).contains(&address) {
+            let index = (address - 0xFF30) as usize;
+            self.channel3.wave_ram[index] = value;
+            return;
+        }
+
+        // NR52 is always writable
+        if address == 0xFF26 {
+            let was_on = self.is_powered();
+            self.nr52 = (self.nr52 & 0x7F) | (value & 0x80);
+
+            if was_on && !self.is_powered() {
+                // Power off: reset all registers
+                self.channel1.reset();
+                self.channel2.reset();
+                self.channel3.reset();
+                self.channel4.reset();
+                self.nr50 = 0;
+                self.nr51 = 0;
+            }
+            return;
+        }
+
+        // Block writes when APU is off
+        if !self.is_powered() {
+            // Exception: length counters (NRx1) can be written when off on DMG
+            match address {
+                0xFF11 => self.channel1.write_register(1, value),
+                0xFF16 => self.channel2.write_register(1, value),
+                0xFF1B => self.channel3.write_register(1, value),
+                0xFF20 => self.channel4.write_register(1, value),
+                _ => {}
+            }
+            return;
+        }
+
+        match address {
+            // Channel 1
+            0xFF10 => self.channel1.write_register(0, value),
+            0xFF11 => self.channel1.write_register(1, value),
+            0xFF12 => self.channel1.write_register(2, value),
+            0xFF13 => self.channel1.write_register(3, value),
+            0xFF14 => self.channel1.write_register(4, value),
+
+            // Channel 2
+            0xFF16 => self.channel2.write_register(1, value),
+            0xFF17 => self.channel2.write_register(2, value),
+            0xFF18 => self.channel2.write_register(3, value),
+            0xFF19 => self.channel2.write_register(4, value),
+
+            // Channel 3
+            0xFF1A => self.channel3.write_register(0, value),
+            0xFF1B => self.channel3.write_register(1, value),
+            0xFF1C => self.channel3.write_register(2, value),
+            0xFF1D => self.channel3.write_register(3, value),
+            0xFF1E => self.channel3.write_register(4, value),
+
+            // Channel 4
+            0xFF20 => self.channel4.write_register(1, value),
+            0xFF21 => self.channel4.write_register(2, value),
+            0xFF22 => self.channel4.write_register(3, value),
+            0xFF23 => self.channel4.write_register(4, value),
+
+            // Control
+            0xFF24 => self.nr50 = value,
+            0xFF25 => self.nr51 = value,
+
+            _ => {}
+        }
+    }
+
+    pub fn step(&mut self, cpu_cycles: u8) {
+        if !self.is_powered() {
+            return;
+        }
+
+        let t_cycles = cpu_cycles as u32 * 4;
+
+        for _ in 0..t_cycles {
+            // Tick frequency timers every T-cycle
+            self.channel1.step_frequency();
+            self.channel2.step_frequency();
+            self.channel3.step_frequency();
+            self.channel4.step_frequency();
+
+            // Frame sequencer
+            self.frame_sequencer_counter += 1;
+            if self.frame_sequencer_counter >= FRAME_SEQUENCER_RATE {
+                self.frame_sequencer_counter = 0;
+                self.clock_frame_sequencer();
+            }
+
+            // Sample generation
+            self.sample_counter += self.sample_rate;
+            if self.sample_counter >= CPU_CLOCK {
+                self.sample_counter -= CPU_CLOCK;
+                let sample = self.mix_samples();
+                self.sample_buffer.push(sample);
+            }
+        }
+    }
+
+    fn clock_frame_sequencer(&mut self) {
+        match self.frame_sequencer_step {
+            0 => {
+                self.clock_length();
+            }
+            1 => {}
+            2 => {
+                self.clock_length();
+                self.clock_sweep();
+            }
+            3 => {}
+            4 => {
+                self.clock_length();
+            }
+            5 => {}
+            6 => {
+                self.clock_length();
+                self.clock_sweep();
+            }
+            7 => {
+                self.clock_envelope();
+            }
+            _ => {}
+        }
+        self.frame_sequencer_step = (self.frame_sequencer_step + 1) % 8;
+    }
+
+    fn clock_length(&mut self) {
+        self.channel1.step_length();
+        self.channel2.step_length();
+        self.channel3.step_length();
+        self.channel4.step_length();
+    }
+
+    fn clock_sweep(&mut self) {
+        self.channel1.step_sweep();
+    }
+
+    fn clock_envelope(&mut self) {
+        self.channel1.step_envelope();
+        self.channel2.step_envelope();
+        self.channel4.step_envelope();
+    }
+
+    fn mix_samples(&self) -> (f32, f32) {
+        let ch1 = self.channel1.output();
+        let ch2 = self.channel2.output();
+        let ch3 = self.channel3.output();
+        let ch4 = self.channel4.output();
+
+        let mut left = 0.0f32;
+        let mut right = 0.0f32;
+
+        // NR51 panning
+        if self.nr51 & 0x10 != 0 {
+            left += ch1;
+        }
+        if self.nr51 & 0x20 != 0 {
+            left += ch2;
+        }
+        if self.nr51 & 0x40 != 0 {
+            left += ch3;
+        }
+        if self.nr51 & 0x80 != 0 {
+            left += ch4;
+        }
+
+        if self.nr51 & 0x01 != 0 {
+            right += ch1;
+        }
+        if self.nr51 & 0x02 != 0 {
+            right += ch2;
+        }
+        if self.nr51 & 0x04 != 0 {
+            right += ch3;
+        }
+        if self.nr51 & 0x08 != 0 {
+            right += ch4;
+        }
+
+        // NR50 volume (0-7)
+        let left_vol = ((self.nr50 >> 4) & 0x07) as f32 + 1.0;
+        let right_vol = (self.nr50 & 0x07) as f32 + 1.0;
+
+        left = left * left_vol / 32.0;
+        right = right * right_vol / 32.0;
+
+        (left, right)
+    }
+
+    pub fn take_samples(&mut self) -> Vec<(f32, f32)> {
+        std::mem::take(&mut self.sample_buffer)
+    }
+}

--- a/src/emulator/gameboy.rs
+++ b/src/emulator/gameboy.rs
@@ -87,6 +87,8 @@ impl Gameboy {
 
         let vblank_interrupt = self.bus.ppu_step(cycles);
 
+        self.bus.apu_step(cycles);
+
         self.handle_interrupts(vblank_interrupt, timer_interrupt);
 
         vblank_interrupt
@@ -167,6 +169,10 @@ impl Gameboy {
         }
 
         cycles
+    }
+
+    pub fn take_audio_samples(&mut self) -> Vec<(f32, f32)> {
+        self.bus.apu.take_samples()
     }
 
     pub fn get_framebuffer(&self) -> &[[u8; 160]] {

--- a/src/emulator/gui.rs
+++ b/src/emulator/gui.rs
@@ -316,6 +316,22 @@ impl eframe::App for GameBoyApp {
                             ));
 
                             ui.separator();
+                            ui.label("APU:");
+                            let nr52 = self.gameboy.bus.apu.read_register(0xFF26);
+                            ui.label(format!(
+                                "Power: {}",
+                                if nr52 & 0x80 != 0 { "ON" } else { "OFF" }
+                            ));
+                            ui.label(format!("NR50: 0x{:02X}  NR51: 0x{:02X}", self.gameboy.bus.apu.nr50, self.gameboy.bus.apu.nr51));
+                            ui.label(format!(
+                                "CH1:{} CH2:{} CH3:{} CH4:{}",
+                                if self.gameboy.bus.apu.channel1.enabled { "ON" } else { "OFF" },
+                                if self.gameboy.bus.apu.channel2.enabled { "ON" } else { "OFF" },
+                                if self.gameboy.bus.apu.channel3.enabled { "ON" } else { "OFF" },
+                                if self.gameboy.bus.apu.channel4.enabled { "ON" } else { "OFF" },
+                            ));
+
+                            ui.separator();
                             if ui.button("Print Terminal Screen").clicked() {
                                 println!("\n=== Debug Screen Print ===");
                                 self.gameboy.print_debug_screen();
@@ -355,6 +371,12 @@ impl eframe::App for GameBoyApp {
                 if ui.button("Print PPU State to Terminal").clicked() {
                     println!("\n=== PPU STATE DEBUG ===");
                     crate::print_ppu_state!(self.gameboy.bus.ppu);
+                    println!("======================");
+                }
+
+                if ui.button("Print APU State to Terminal").clicked() {
+                    println!("\n=== APU STATE DEBUG ===");
+                    crate::print_apu_state!(self.gameboy.bus.apu);
                     println!("======================");
                 }
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,3 +1,4 @@
+pub mod apu;
 pub mod bus;
 pub mod cpu;
 pub mod gameboy;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -89,3 +89,17 @@ macro_rules! print_ppu_state {
         println!("  LCD Enabled: {}", $ppu.is_lcd_enabled());
     };
 }
+
+#[macro_export]
+macro_rules! print_apu_state {
+    ($apu:expr) => {
+        println!("APU State:");
+        println!("  NR50: 0x{:02X}  NR51: 0x{:02X}  NR52: 0x{:02X}", $apu.nr50, $apu.nr51, $apu.read_register(0xFF26));
+        println!("  CH1: {}  CH2: {}  CH3: {}  CH4: {}",
+            if $apu.channel1.enabled { "ON" } else { "OFF" },
+            if $apu.channel2.enabled { "ON" } else { "OFF" },
+            if $apu.channel3.enabled { "ON" } else { "OFF" },
+            if $apu.channel4.enabled { "ON" } else { "OFF" },
+        );
+    };
+}

--- a/tests/apu.rs
+++ b/tests/apu.rs
@@ -1,0 +1,228 @@
+#[cfg(test)]
+mod tests {
+    use emulator::apu::APU;
+
+    #[test]
+    fn test_apu_new() {
+        let apu = APU::new();
+
+        assert_eq!(apu.nr50, 0);
+        assert_eq!(apu.nr51, 0);
+        assert_eq!(apu.nr52, 0);
+        assert!(!apu.channel1.enabled);
+        assert!(!apu.channel2.enabled);
+        assert!(!apu.channel3.enabled);
+        assert!(!apu.channel4.enabled);
+
+        // NR52 should read as 0x70 (bits 4-6 always 1, power off, no channels)
+        assert_eq!(apu.read_register(0xFF26), 0x70);
+    }
+
+    #[test]
+    fn test_nr52_power_control() {
+        let mut apu = APU::new();
+
+        // Power on
+        apu.write_register(0xFF26, 0x80);
+        assert_eq!(apu.read_register(0xFF26) & 0x80, 0x80);
+
+        // Write some registers while on
+        apu.write_register(0xFF24, 0x77);
+        apu.write_register(0xFF25, 0xFF);
+        assert_eq!(apu.nr50, 0x77);
+        assert_eq!(apu.nr51, 0xFF);
+
+        // Power off - should reset registers
+        apu.write_register(0xFF26, 0x00);
+        assert_eq!(apu.read_register(0xFF26) & 0x80, 0x00);
+        assert_eq!(apu.nr50, 0x00);
+        assert_eq!(apu.nr51, 0x00);
+    }
+
+    #[test]
+    fn test_wave_ram_read_write() {
+        let mut apu = APU::new();
+
+        // Wave RAM is always writable, even when APU is off
+        for i in 0..16u8 {
+            apu.write_register(0xFF30 + i as u16, i * 0x11);
+        }
+
+        for i in 0..16u8 {
+            assert_eq!(apu.read_register(0xFF30 + i as u16), i * 0x11);
+        }
+
+        // Wave RAM survives power cycle
+        apu.write_register(0xFF26, 0x80); // on
+        apu.write_register(0xFF26, 0x00); // off
+        for i in 0..16u8 {
+            assert_eq!(apu.read_register(0xFF30 + i as u16), i * 0x11);
+        }
+    }
+
+    #[test]
+    fn test_channel1_trigger() {
+        let mut apu = APU::new();
+
+        // Power on
+        apu.write_register(0xFF26, 0x80);
+
+        // Configure channel 1: volume, frequency, trigger
+        apu.write_register(0xFF12, 0xF0); // NR12: volume 15, no envelope
+        apu.write_register(0xFF13, 0x00); // NR13: freq low
+        apu.write_register(0xFF14, 0x80); // NR14: trigger
+
+        assert!(apu.channel1.enabled);
+        // NR52 bit 0 should be set
+        assert_eq!(apu.read_register(0xFF26) & 0x01, 0x01);
+    }
+
+    #[test]
+    fn test_length_counter_disables_channel() {
+        let mut apu = APU::new();
+
+        // Power on
+        apu.write_register(0xFF26, 0x80);
+
+        // Channel 1: short length, enable length counter
+        apu.write_register(0xFF11, 0x3F); // NR11: duty 0, length = 64 - 63 = 1
+        apu.write_register(0xFF12, 0xF0); // NR12: volume 15
+        apu.write_register(0xFF13, 0x00); // NR13: freq low
+        apu.write_register(0xFF14, 0xC0); // NR14: trigger + length enable
+
+        assert!(apu.channel1.enabled);
+
+        // Step enough to trigger frame sequencer step 0 (length counter)
+        // Frame sequencer ticks every 8192 T-cycles
+        apu.step(255); // 255 * 4 = 1020 T-cycles
+        for _ in 0..8 {
+            apu.step(255); // 8 * 1020 = 8160 more
+        }
+
+        // After enough steps, the length counter should have expired
+        // (length was 1, one length clock sets it to 0 and disables channel)
+        assert!(!apu.channel1.enabled);
+    }
+
+    #[test]
+    fn test_register_read_masks() {
+        let apu = APU::new();
+
+        // NR13 (0xFF13) is write-only, should read as 0xFF
+        assert_eq!(apu.read_register(0xFF13), 0xFF);
+
+        // NR23 (0xFF18) is write-only, should read as 0xFF
+        assert_eq!(apu.read_register(0xFF18), 0xFF);
+
+        // NR33 (0xFF1D) is write-only, should read as 0xFF
+        assert_eq!(apu.read_register(0xFF1D), 0xFF);
+
+        // NR14 (0xFF14) bit 6 readable, rest masked → should read with 0xBF mask
+        assert_eq!(apu.read_register(0xFF14) & 0xBF, 0xBF);
+
+        // NR10 (0xFF10) upper bit masked
+        assert_eq!(apu.read_register(0xFF10) & 0x80, 0x80);
+
+        // Unused register 0xFF15 should read 0xFF
+        assert_eq!(apu.read_register(0xFF15), 0xFF);
+
+        // Unused register 0xFF1F should read 0xFF
+        assert_eq!(apu.read_register(0xFF1F), 0xFF);
+    }
+
+    #[test]
+    fn test_apu_off_blocks_writes() {
+        let mut apu = APU::new();
+
+        // APU is off by default (NR52 bit 7 = 0)
+        assert_eq!(apu.read_register(0xFF26) & 0x80, 0x00);
+
+        // Writes to NR50/NR51 should be blocked when off
+        apu.write_register(0xFF24, 0x77);
+        assert_eq!(apu.nr50, 0x00);
+
+        apu.write_register(0xFF25, 0xFF);
+        assert_eq!(apu.nr51, 0x00);
+
+        // NR52 write should always work
+        apu.write_register(0xFF26, 0x80);
+        assert_eq!(apu.read_register(0xFF26) & 0x80, 0x80);
+
+        // Wave RAM should always be writable
+        apu.write_register(0xFF26, 0x00); // turn off again
+        apu.write_register(0xFF30, 0xAB);
+        assert_eq!(apu.read_register(0xFF30), 0xAB);
+
+        // Length counters (NRx1) can be written when off on DMG
+        apu.write_register(0xFF11, 0x80); // NR11
+        assert_eq!(apu.channel1.nr1, 0x80);
+    }
+
+    #[test]
+    fn test_noise_channel_lfsr() {
+        let mut apu = APU::new();
+
+        // Power on
+        apu.write_register(0xFF26, 0x80);
+
+        // Configure noise channel
+        apu.write_register(0xFF21, 0xF0); // NR42: volume 15
+        apu.write_register(0xFF22, 0x00); // NR43: divisor 0, shift 0, 15-bit
+        apu.write_register(0xFF23, 0x80); // NR44: trigger
+
+        assert!(apu.channel4.enabled);
+
+        // After trigger, LFSR should be 0x7FFF
+        // (internal state, but we can check channel is producing output)
+        // Step a bit to get some noise output
+        apu.step(4);
+
+        // Channel should still be enabled (no length counter active)
+        assert!(apu.channel4.enabled);
+    }
+
+    #[test]
+    fn test_sample_generation() {
+        let mut apu = APU::new();
+
+        // Power on and configure for audible output
+        apu.write_register(0xFF26, 0x80); // NR52: power on
+        apu.write_register(0xFF24, 0x77); // NR50: max volume both sides
+        apu.write_register(0xFF25, 0xFF); // NR51: all channels to both outputs
+
+        // Enable channel 1
+        apu.write_register(0xFF11, 0x80); // NR11: 50% duty
+        apu.write_register(0xFF12, 0xF0); // NR12: volume 15
+        apu.write_register(0xFF13, 0xD6); // NR13: freq low (for ~440Hz)
+        apu.write_register(0xFF14, 0x87); // NR14: trigger + freq high
+
+        // Step enough to generate some samples
+        // At 44100 Hz sample rate and 4194304 Hz CPU clock,
+        // we need ~95 T-cycles per sample, so stepping ~1000 M-cycles
+        // should give us plenty of samples
+        for _ in 0..100 {
+            apu.step(10);
+        }
+
+        let samples = apu.take_samples();
+        assert!(!samples.is_empty(), "APU should have generated samples");
+
+        // Verify samples are in valid range [-1.0, 1.0]
+        for (left, right) in &samples {
+            assert!(
+                *left >= -1.0 && *left <= 1.0,
+                "Left sample out of range: {}",
+                left
+            );
+            assert!(
+                *right >= -1.0 && *right <= 1.0,
+                "Right sample out of range: {}",
+                right
+            );
+        }
+
+        // At least some samples should be non-zero (channel 1 is active)
+        let has_nonzero = samples.iter().any(|(l, r)| *l != 0.0 || *r != 0.0);
+        assert!(has_nonzero, "Expected some non-zero audio samples");
+    }
+}


### PR DESCRIPTION
## Summary

- Add Game Boy APU emulation with all 4 audio channels: 2 square wave channels (with/without sweep), 1 wave channel (Wave RAM), 1 noise channel (LFSR)
- Integrate APU into the Bus/Gameboy execution loop following the existing component pattern (Timer, PPU, Joypad)
- Add `cpal`-based audio output at 44100 Hz stereo with shared buffer between emulation and audio thread
- Add APU debug view in GUI panel and `print_apu_state!` logging macro
- Fix frame pacing: replace fixed 8ms/2-frame batch with a time accumulator targeting 59.7275 Hz (exact Game Boy refresh rate)

## Details

### APU implementation (`src/emulator/apu.rs`)
- `SquareChannel`: duty cycle, length counter, volume envelope, frequency sweep (ch1)
- `WaveChannel`: 16-byte Wave RAM (32 x 4-bit samples), volume code, DAC control
- `NoiseChannel`: 15-bit LFSR, divisor, width mode
- Frame sequencer at 512 Hz (8 steps): length counter, sweep, volume envelope
- Register read masks (write-only bits return 1), power on/off behavior (NR52)
- Sample mixing with NR50 volume and NR51 panning

### GUI audio (`src/emulator/gui.rs`)
- `cpal` stream consuming samples from `Arc<Mutex<VecDeque>>` shared buffer
- Mute/Unmute button + M key toggle
- Buffer capped at ~1 second to prevent unbounded growth

### Frame timing fix
- Time accumulator consuming 16.74ms per frame (1/59.7275 Hz)
- Max 4 frames catchup to avoid spiral of death in debug builds

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` — 103 tests pass (82 CPU + 12 PPU + 9 APU)
- [x] `cargo clippy` — no warnings
- [ ] `cargo run --release` with `resources/tetris.gb` — verify audio is audible and frame rate is stable at ~60 FPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)